### PR TITLE
Acceleration module test is re-enabled

### DIFF
--- a/src/fpga_managing/CMakeLists.txt
+++ b/src/fpga_managing/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(fpga_managing
 			"memory_block_interface.hpp"
 			"memory_manager.cpp"
 			"memory_manager.hpp"
+			"memory_manager_interface.hpp"
 			${OS_DEPENDENT_MEMORY_BLOCK}
 			)
 

--- a/src/fpga_managing/acceleration_module.hpp
+++ b/src/fpga_managing/acceleration_module.hpp
@@ -1,11 +1,11 @@
 #pragma once
 #include <cstdint>
 
-#include "memory_manager.hpp"
+#include "memory_manager_interface.hpp"
 
 class AccelerationModule {
  private:
-  MemoryManager* memory_manager_;
+  MemoryManagerInterface* memory_manager_;
   const int module_position_;
 
   auto CalculateMemoryMappedAddress(int module_internal_address)
@@ -14,7 +14,7 @@ class AccelerationModule {
  protected:
   void WriteToModule(int module_internal_address, uint32_t write_data);
   auto ReadFromModule(int module_internal_address) -> volatile uint32_t;
-  AccelerationModule(MemoryManager* memory_manager,
+  AccelerationModule(MemoryManagerInterface* memory_manager,
                      int module_position)
       : memory_manager_(memory_manager),
         module_position_(module_position){};

--- a/src/fpga_managing/dma.hpp
+++ b/src/fpga_managing/dma.hpp
@@ -4,12 +4,12 @@
 #include "acceleration_module.hpp"
 #include "dma_interface.hpp"
 
-#include "memory_manager.hpp"
+#include "memory_manager_interface.hpp"
 
 class DMA : public AccelerationModule, public DMAInterface {
  public:
   ~DMA() override;
-  explicit DMA(MemoryManager* memory_manager)
+  explicit DMA(MemoryManagerInterface* memory_manager)
       : AccelerationModule(memory_manager, 0){};
 
   void SetInputControllerParams(int stream_id, int dd_rburst_size,

--- a/src/fpga_managing/filter.hpp
+++ b/src/fpga_managing/filter.hpp
@@ -5,7 +5,7 @@
 #include "filter_config_values.hpp"
 #include "filter_interface.hpp"
 
-#include "memory_manager.hpp"
+#include "memory_manager_interface.hpp"
 
 class Filter : public AccelerationModule, public FilterInterface {
  private:
@@ -15,7 +15,7 @@ class Filter : public AccelerationModule, public FilterInterface {
 
  public:
   ~Filter() override;
-  explicit Filter(MemoryManager* memory_manager, int module_position)
+  explicit Filter(MemoryManagerInterface* memory_manager, int module_position)
       : AccelerationModule(memory_manager, module_position){};
 
   void FilterSetStreamIDs(int stream_id_input, int stream_id_valid_output,

--- a/src/fpga_managing/fpga_manager.hpp
+++ b/src/fpga_managing/fpga_manager.hpp
@@ -2,7 +2,7 @@
 #include <cstdint>
 #include <vector>
 #include "dma.hpp"
-#include "memory_manager.hpp"
+#include "memory_manager_interface.hpp"
 #include <string>
 #include "filter.hpp"
 
@@ -13,7 +13,7 @@ class FPGAManager {
                               int record_size, int record_count);
   auto RunQueryAcceleration() -> std::vector<int>;
 
-  explicit FPGAManager(MemoryManager* memory_manager)
+  explicit FPGAManager(MemoryManagerInterface* memory_manager)
       : memory_manager_{memory_manager},
         dma_engine_{memory_manager} {};
 
@@ -22,7 +22,7 @@ class FPGAManager {
   bool input_stream_active_[kMaxStreamAmount] = {false};
   bool output_stream_active_[kMaxStreamAmount] = {false};
 
-  MemoryManager* memory_manager_;
+  MemoryManagerInterface* memory_manager_;
   DMA dma_engine_;
 
   void FindActiveStreams(std::vector<int>& active_input_stream_ids,

--- a/src/fpga_managing/join.hpp
+++ b/src/fpga_managing/join.hpp
@@ -1,12 +1,13 @@
 #pragma once
 #include "acceleration_module.hpp"
 #include "join_interface.hpp"
+#include "memory_manager_interface.hpp"
 
 class Join : public AccelerationModule, public JoinInterface {
  private:
  public:
   ~Join() override;
-  explicit Join(MemoryManager* memory_manager, int module_position)
+  explicit Join(MemoryManagerInterface* memory_manager, int module_position)
       : AccelerationModule(memory_manager, module_position){};
 
   void DefineOutputStream(int output_stream_chunk_count, int first_input_stream_id, int second_input_stream_id,

--- a/src/fpga_managing/memory_manager.cpp
+++ b/src/fpga_managing/memory_manager.cpp
@@ -6,6 +6,8 @@
 #include "virtual_memory_block.hpp"
 #endif
 
+MemoryManager::~MemoryManager() = default;
+
 MemoryManager::MemoryManager(const std::string& bitstream_name) {
 #ifdef _FPGA_AVAILABLE
   acceleration_instance_ = pr_manager_.fpgaLoadStatic(bitstream_name);

--- a/src/fpga_managing/memory_manager.hpp
+++ b/src/fpga_managing/memory_manager.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include "memory_manager_interface.hpp"
 #include "memory_block_interface.hpp"
 #ifdef _FPGA_AVAILABLE
 #include "cynq.h"
@@ -11,7 +12,7 @@
 #include <vector>
 #endif
 
-class MemoryManager {
+class MemoryManager : public MemoryManagerInterface {
  private:
 #ifdef _FPGA_AVAILABLE
   int memory_block_count_ = 0;
@@ -24,7 +25,8 @@ class MemoryManager {
   std::vector<uint32_t> register_space_;
 #endif
  public:
+  ~MemoryManager() override;
   explicit MemoryManager(const std::string& bitstream_name);
-  auto AllocateMemoryBlock() -> std::unique_ptr<MemoryBlockInterface>;
-  auto GetVirtualRegisterAddress(int offset) -> volatile uint32_t*;
+  auto AllocateMemoryBlock() -> std::unique_ptr<MemoryBlockInterface> override;
+  auto GetVirtualRegisterAddress(int offset) -> volatile uint32_t* override;
 };

--- a/src/fpga_managing/memory_manager_interface.hpp
+++ b/src/fpga_managing/memory_manager_interface.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+
+#include "memory_block_interface.hpp"
+class MemoryManagerInterface {
+ public:
+  virtual ~MemoryManagerInterface() = default;
+
+  virtual auto AllocateMemoryBlock() -> std::unique_ptr<MemoryBlockInterface> = 0;
+  virtual auto GetVirtualRegisterAddress(int offset) -> volatile uint32_t* = 0;
+};

--- a/tests/acceleration_module_test.cpp
+++ b/tests/acceleration_module_test.cpp
@@ -1,50 +1,69 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <limits.h>
 
+#include "mock_memory_manager.hpp"
 #include "mock_acceleration_module.hpp"
 namespace {
 const int kDefaultValue = -1;
 
-// Disabled for now due to missing mock acceleration instances needed for
-// acceleration modules.
-/*
 TEST(AccelerationModuleTest, WriteToModule) {
   std::vector<uint32_t> memory_pointer(524288, kDefaultValue);
+  MockMemoryManager mock_memory_manager;
+  MockAccelerationModule mock_module(&mock_memory_manager, 0);
 
-  MockAccelerationModule mock_module(memory_pointer.data(), 0);
+  EXPECT_CALL(mock_memory_manager, GetVirtualRegisterAddress(0))
+      .Times(1)
+      .WillOnce(::testing::Return(&memory_pointer[0]));
 
   EXPECT_EQ(UINT_MAX, memory_pointer[0]);
   mock_module.WriteToModule(0, 0);
   EXPECT_EQ(0, memory_pointer[0]);
 
+  EXPECT_CALL(mock_memory_manager, GetVirtualRegisterAddress(1))
+      .Times(1)
+      .WillOnce(::testing::Return(&memory_pointer[1]));
+
   EXPECT_EQ(UINT_MAX, memory_pointer[1]);
-  mock_module.WriteToModule(1 * sizeof(uint32_t), 10);
+  mock_module.WriteToModule(1, 10);
   EXPECT_EQ(10, memory_pointer[1]);
 
-  MockAccelerationModule second_mock_module(memory_pointer.data(), 1);
+  MockAccelerationModule second_mock_module(&mock_memory_manager, 1);
 
-  EXPECT_EQ(UINT_MAX, memory_pointer[262144]);
+  EXPECT_CALL(mock_memory_manager, GetVirtualRegisterAddress(1024 * 1024))
+      .Times(2)
+      .WillRepeatedly(::testing::Return(&memory_pointer[2]));
+
+  EXPECT_EQ(UINT_MAX, memory_pointer[2]);
   second_mock_module.WriteToModule(0, 1);
-  EXPECT_EQ(1, memory_pointer[262144]);
+  EXPECT_EQ(1, memory_pointer[2]);
+
   second_mock_module.WriteToModule(0, 11);
-  EXPECT_EQ(11, memory_pointer[262144]);
+  EXPECT_EQ(11, memory_pointer[2]);
 }
 
 TEST(AccelerationModuleTest, ReadFromModule) {
   std::vector<uint32_t> memory_pointer(524288, kDefaultValue);
+  MockMemoryManager mock_memory_manager;
+  MockAccelerationModule mock_module(&mock_memory_manager, 0);
 
-  MockAccelerationModule mock_module(memory_pointer.data(), 0);
+  EXPECT_CALL(mock_memory_manager, GetVirtualRegisterAddress(2))
+      .Times(2)
+      .WillRepeatedly(::testing::Return(&memory_pointer[0]));
 
-  EXPECT_EQ(kDefaultValue, mock_module.ReadFromModule(2 * sizeof(uint32_t)));
-  memory_pointer[2] = 100;
-  EXPECT_EQ(100, mock_module.ReadFromModule(2 * sizeof(uint32_t)));
+  EXPECT_EQ(kDefaultValue, mock_module.ReadFromModule(2));
+  memory_pointer[0] = 100;
+  EXPECT_EQ(100, mock_module.ReadFromModule(2));
 
-  MockAccelerationModule second_mock_module(memory_pointer.data(), 1);
+  MockAccelerationModule second_mock_module(&mock_memory_manager, 1);
+
+  EXPECT_CALL(mock_memory_manager, GetVirtualRegisterAddress(1024 * 1024 + 2))
+      .Times(2)
+      .WillRepeatedly(::testing::Return(&memory_pointer[1]));
 
   EXPECT_EQ(kDefaultValue,
-            second_mock_module.ReadFromModule(2 * sizeof(uint32_t)));
-  memory_pointer[262146] = 101;
-  EXPECT_EQ(101, second_mock_module.ReadFromModule(2 * sizeof(uint32_t)));
+            second_mock_module.ReadFromModule(2));
+  memory_pointer[1] = 101;
+  EXPECT_EQ(101, second_mock_module.ReadFromModule(2));
 }
-*/
 }  // namespace

--- a/tests/mock_acceleration_module.cpp
+++ b/tests/mock_acceleration_module.cpp
@@ -2,9 +2,6 @@
 
 #include <cstdint>
 
-MockAccelerationModule::MockAccelerationModule(MemoryManager* memory_manager,
-                                               int module_position)
-    : AccelerationModule(memory_manager, module_position) {}
 MockAccelerationModule::~MockAccelerationModule() = default;
 
 void MockAccelerationModule::WriteToModule(int module_internal_address,

--- a/tests/mock_acceleration_module.hpp
+++ b/tests/mock_acceleration_module.hpp
@@ -2,11 +2,13 @@
 #include <cstdint>
 
 #include "acceleration_module.hpp"
-#include "memory_manager.hpp"
+#include "memory_manager_interface.hpp"
 
 class MockAccelerationModule : public AccelerationModule {
  public:
-  MockAccelerationModule(MemoryManager* memory_manager, int module_position);
+  MockAccelerationModule(MemoryManagerInterface* memory_manager,
+                                                 int module_position)
+      : AccelerationModule(memory_manager, module_position) {}
   ~MockAccelerationModule() override;
   void WriteToModule(int module_internal_address, uint32_t write_data);
   auto ReadFromModule(int module_internal_address) -> uint32_t;

--- a/tests/mock_memory_manager.hpp
+++ b/tests/mock_memory_manager.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+
+#include "memory_manager_interface.hpp"
+#include "memory_block_interface.hpp"
+#include "gmock/gmock.h"
+class MockMemoryManager : public MemoryManagerInterface {
+ public:
+  MOCK_METHOD(std::unique_ptr<MemoryBlockInterface>, AllocateMemoryBlock, (), (override));
+  MOCK_METHOD(volatile uint32_t*, GetVirtualRegisterAddress, (int offset),
+              (override));
+};


### PR DESCRIPTION
Added a memory_manager interface such that it can be mocked for acceleration_module class tests.