### PR TITLE
Added a global reset signal write to the DMA

### DIFF
--- a/apps/fpga_run.cpp
+++ b/apps/fpga_run.cpp
@@ -5,8 +5,8 @@
 auto main() -> int {
   query_scheduling_data::QueryNode filtering_query_once = {
       {"CAR_DATA.csv"},
-                                    {"CAR_FILTER_DATA.csv"},
-                                    operation_types::QueryOperation::kFilter};
+      {"CAR_FILTER_DATA.csv"},
+      operation_types::QueryOperation::kFilter};
 
   query_scheduling_data::QueryNode pass_through_1k_data = {
       {"CAR_DATA.csv"},
@@ -32,8 +32,8 @@ auto main() -> int {
 
   query_scheduling_data::QueryNode join_query_once = {
       {"CAR_DATA.csv", "CUSTOMER_DATA_FOR_JOIN.csv"},
-                               {"JOIN_DATA.csv"},
-                               operation_types::QueryOperation::kJoin};
+      {"JOIN_DATA.csv"},
+      operation_types::QueryOperation::kJoin};
 
   query_scheduling_data::QueryNode merge_sort_query_8k_once_double = {
       {"CAR_DATA_HALF_SORTED_8K_64WAY.csv"},
@@ -50,7 +50,9 @@ auto main() -> int {
       {"CAR_DATA_SORTED.csv"},
       operation_types::QueryOperation::kMergeSort};
 
-  QueryManager::RunQueries(
-      {filtering_query_once, merge_sort_query_8k_once_double, join_query_once});
+  QueryManager::RunQueries({filtering_query_once, filtering_query_once,
+                            merge_sort_query_8k_once_double,
+                            merge_sort_query_8k_once_double, join_query_once,
+                            join_query_once});
   return 0;
 }

--- a/src/fpga_managing/dma.cpp
+++ b/src/fpga_managing/dma.cpp
@@ -230,3 +230,9 @@ auto DMA::GetValidWriteCyclesCount() -> volatile uint64_t {
   auto low = AccelerationModule::ReadFromModule(0x8014);
   return ((static_cast<uint64_t>(high)) << 32) | (static_cast<uint64_t>(low));
 }
+
+const int kResetDuration = 8;
+
+void DMA::GlobalReset() {
+  AccelerationModule::WriteToModule(8, kResetDuration);
+}

--- a/src/fpga_managing/dma.hpp
+++ b/src/fpga_managing/dma.hpp
@@ -75,4 +75,6 @@ class DMA : public AccelerationModule, public DMAInterface {
   auto GetRuntime() -> volatile uint64_t override;
   auto GetValidReadCyclesCount() -> volatile uint64_t override;
   auto GetValidWriteCyclesCount() -> volatile uint64_t override;
+
+  void GlobalReset() override;
 };

--- a/src/fpga_managing/dma_interface.hpp
+++ b/src/fpga_managing/dma_interface.hpp
@@ -66,4 +66,6 @@ class DMAInterface {
   virtual auto GetRuntime() -> volatile uint64_t = 0;
   virtual auto GetValidReadCyclesCount() -> volatile uint64_t = 0;
   virtual auto GetValidWriteCyclesCount() -> volatile uint64_t = 0;
+
+  virtual void GlobalReset() = 0;
 };

--- a/src/fpga_managing/fpga_manager.cpp
+++ b/src/fpga_managing/fpga_manager.cpp
@@ -17,6 +17,8 @@
 // Then the modules and streams can be set up accordingly.
 void FPGAManager::SetupQueryAcceleration(
     const std::vector<AcceleratedQueryNode>& query_nodes) {
+  dma_engine_.GlobalReset();
+
   // ila_module_ = std::make_optional (ILA(memory_manager_));
   /*if (ila_module_) {
     ila_module_.value().startAxiILA();

--- a/tests/mock_dma.hpp
+++ b/tests/mock_dma.hpp
@@ -82,4 +82,6 @@ class MockDMA : public DMAInterface {
   MOCK_METHOD(volatile uint64_t, GetRuntime, (), (override));
   MOCK_METHOD(volatile uint64_t, GetValidReadCyclesCount, (), (override));
   MOCK_METHOD(volatile uint64_t, GetValidWriteCyclesCount, (), (override));
+
+  MOCK_METHOD(void, GlobalReset, (), (override));
 };


### PR DESCRIPTION
Changed the FPGA manager to use a global reset such that multiple merge sort queries would output the correct result.